### PR TITLE
Move ThreeJS to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11069,11 +11069,8 @@
     },
     "packages/core": {
       "name": "@unithree/core",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
-      "dependencies": {
-        "three": "^0.155.0"
-      },
       "devDependencies": {
         "@types/jest": "^29.1.x",
         "@types/jsdom": "^21.1.6",
@@ -11091,6 +11088,9 @@
         "ts-loader": "^9.5.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.9.5"
+      },
+      "peerDependencies": {
+        "three": ">=0.155.0"
       }
     },
     "packages/core/node_modules/@babel/code-frame": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,6 +8,14 @@ inspired by it and entity/component models.
 
 ## Documentation
 
+### Setup
+
+This is a ThreeJS based project so when installing via NPM please use:
+
+```bash
+npm install three @types/three @unithree/core
+```
+
 ### Core Concepts
 
 Unithree is built around a central state that houses the frame loop. This provides the processing of

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Bungalow12/Unithree/issues"
   },
   "homepage": "https://github.com/Bungalow12/Unithree#readme",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Unity3D inspired ThreeJS framework",
   "source": "./src/index.ts",
   "files": [
@@ -61,7 +61,6 @@
     "access": "public"
   },
   "dependencies": {
-    "three": "^0.155.0"
   },
   "devDependencies": {
     "@types/jest": "^29.1.x",
@@ -81,6 +80,9 @@
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.9.5"
   },
+  "peerDependencies": {
+    "three": ">=0.155.0"
+  },
   "scripts": {
     "build": "npm run compile",
     "test": "jest",
@@ -97,6 +99,7 @@
     "3D",
     "unity",
     "threejs",
-    "typescript"
+    "typescript",
+    "webgl"
   ]
 }


### PR DESCRIPTION
Should have made ThreeJS a peerDependency. This is likely the cause of the type issue presented by editors for the `entity.add()` function and `instantiateObject` function